### PR TITLE
テンプレート関連のAPIをMongoDBに繋いだ

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,56 +1,33 @@
 const express = require('express');
 const app = express();
+
 const mongoose = require('mongoose');
 const databaseUrl = process.env.MONGO_DATABASE || "mongodb://localhost/myapp"
+const { IssueTemplate } = require("./models/issueTemplate");
 
 // reqest bodyをパースする
 app.use(express.json())
+app.use(express.urlencoded({ extended: true }));
 
 mongoose.connect(databaseUrl, { useNewUrlParser: true });
 
-const dummy_issue_item = {
-  order: 1,
-  name: "hogehoge",
-  description: "aaaaaaaaaaa"
-}
-
-const dummy_issue_item2 = {
-  order: 1,
-  name: "hogehoge",
-  description: "aaaaaaaaaaa"
-}
-
-const dummy_templates = [
-  {
-    _id: "dummy1",
-    title: "",
-    issue_items: [dummy_issue_item]
-  },
-  {
-    _id: "dummy2",
-    title: "",
-    issue_items: [dummy_issue_item, dummy_issue_item2]
-  }
-]
-
-const new_dummy_template = {
-  _id: "dummy_added",
-  title: "ああああああああああ",
-  issue_items: [dummy_issue_item, dummy_issue_item2]
-}
-
-app.get('/api/templates', (req, res) => {
-  res.json(dummy_templates);
+app.get('/api/templates', async (req, res) => {
+  const doc = await IssueTemplate.find({"title":"hogehogefugafuga"}).exec();
+  res.json(doc);
 })
 
-app.post('/api/templates', (req, res) => {
-  dummy_templates.push(new_dummy_template)
-  res.json(new_dummy_template);
+app.post('/api/templates', async (req, res) => {
+  const issute_template = new IssueTemplate();
+  issute_template.title = req.body.title;
+  issute_template.issue_items = req.body.issue_items;
+  const doc = await issute_template.save();
+  res.json(doc);
 })
 
-app.get('/api/templates/:template_id', (req, res) => {
+app.get('/api/templates/:template_id', async (req, res) => {
   const templateId = req.params.template_id;
-  res.json(dummy_templates[0]);
+  const doc = await IssueTemplate.find({ _id: templateId }).exec();
+  res.json(doc);
 })
 
 app.get('/api/issues', (req, res) => {


### PR DESCRIPTION
## やったこと
以下のエンドポイントをMongoDBに繋いでデータを永続化するようにした
- テンプレート一覧
- テンプレート詳細
- テンプレート作成

## やってないこと
- エラーハンドリング（後でやります）

## 参考（確認してもらえると嬉しい）
↓確認用コマンド

一覧
```
curl  localhost:8080/api/templates
```

一覧
```
curl  localhost:8080/api/templates/<_id of doucment>
eg) curl  localhost:8080/api/templates/5e77f462dcc9c10235df9c64
```

作成
```
curl -X POST -H "Content-Type: application/json" -d '{"title":"sensuikan1973", "issue_items":[]}' localhost:8080/api/templates
```